### PR TITLE
fallback to what is set in the config when not passing the sensor_pow…

### DIFF
--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -613,7 +613,7 @@ def treat_runtimeparams(
             model_type = runtimeparams["model_type"]
         params["passed_data"]["model_type"] = model_type
         if "var_model" not in runtimeparams.keys():
-            var_model = self.retrieve_hass_conf["sensor_power_load_no_var_loads"]
+            var_model = params["retrieve_hass_conf"]["sensor_power_load_no_var_loads"]
         else:
             var_model = runtimeparams["var_model"]
         params["passed_data"]["var_model"] = var_model

--- a/src/emhass/utils.py
+++ b/src/emhass/utils.py
@@ -613,7 +613,7 @@ def treat_runtimeparams(
             model_type = runtimeparams["model_type"]
         params["passed_data"]["model_type"] = model_type
         if "var_model" not in runtimeparams.keys():
-            var_model = "sensor.power_load_no_var_loads"
+            var_model = self.retrieve_hass_conf["sensor_power_load_no_var_loads"]
         else:
             var_model = runtimeparams["var_model"]
         params["passed_data"]["var_model"] = var_model


### PR DESCRIPTION
…er_load_no_var_loads as runtime parameter

Attempt to fix the "ERROR - emhass.web_server - The retrieved JSON is empty, A sensor:sensor.power_load_no_var_loads may have 0 days of history, passed sensor may not be correct, or days to retrieve is set too heigh" 

 even if you have another sensor set in your config file.